### PR TITLE
Handle short audio resampling edge cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pelagos-voice-agent",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"

--- a/server.js
+++ b/server.js
@@ -122,22 +122,25 @@ function mulawToPCM16(mu) {
   return out;
 }
 
-function resampleLinearPCM16(input, inRate, outRate) {
-  if (inRate === outRate) return input;
-  const inSamples = input.length / 2;
-  const outSamples = Math.round(inSamples * outRate / inRate);
-  const out = Buffer.alloc(outSamples * 2);
-  for (let i = 0; i < outSamples; i++) {
-    const t = i * (inSamples - 1) / (outSamples - 1);
-    const i0 = Math.floor(t), i1 = Math.min(i0 + 1, inSamples - 1);
-    const frac = t - i0;
-    const s0 = input.readInt16LE(i0 * 2);
-    const s1 = input.readInt16LE(i1 * 2);
-    const s = (1 - frac) * s0 + frac * s1;
-    out.writeInt16LE(Math.max(-32768, Math.min(32767, s | 0)), i * 2);
+  function resampleLinearPCM16(input, inRate, outRate) {
+    if (inRate === outRate) return input;
+    const inSamples = input.length / 2;
+    const outSamples = Math.round(inSamples * outRate / inRate);
+    if (inSamples < 2 || outSamples < 2) {
+      return Buffer.alloc(outSamples * 2);
+    }
+    const out = Buffer.alloc(outSamples * 2);
+    for (let i = 0; i < outSamples; i++) {
+      const t = i * (inSamples - 1) / (outSamples - 1);
+      const i0 = Math.floor(t), i1 = Math.min(i0 + 1, inSamples - 1);
+      const frac = t - i0;
+      const s0 = input.readInt16LE(i0 * 2);
+      const s1 = input.readInt16LE(i1 * 2);
+      const s = (1 - frac) * s0 + frac * s1;
+      out.writeInt16LE(Math.max(-32768, Math.min(32767, s | 0)), i * 2);
+    }
+    return out;
   }
-  return out;
-}
 
 // WebSocket endpoint - registered as separate plugin to avoid CORS conflicts
 fastify.register(async function (fastify) {


### PR DESCRIPTION
## Summary
- guard `resampleLinearPCM16` against very short inputs to avoid divide-by-zero errors
- fix package entry point and add ignore rules for local files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1364e5483228a03d35faf6b39df